### PR TITLE
MSI provider swapped out for Windows

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,7 @@ class vagrant (
     }
     windows: {
       $vagrant_url = "${base_url}/Vagrant_${version}.msi"
-      $vagrant_provider = 'msi'
+      $vagrant_provider = 'windows'
     }
     default: {
       fail("Unrecognized operating system: ${::operatingsystem}")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,11 @@
 #    version  => '1.2.2'
 #  }
 #
-class vagrant ($git_hash = '7ec0ee1d00a916f80b109a298bab08e391945243', $version = '1.2.7') {
+class vagrant (
+  $git_hash = '7ec0ee1d00a916f80b109a298bab08e391945243',
+  $version = '1.2.7',
+) {
+
   $base_url = "http://files.vagrantup.com/packages/${git_hash}"
 
   case $::operatingsystem {


### PR DESCRIPTION
Hi, your module worked pretty well for me tonight. Thank you! 

I'm offering two small commits here. The first just makes your class parameters cleaner so that future changes to them are really easy to see in git diffs. The second swaps out the deprecated msi package provider for the windows provider which is basically the same, but better.

Be warned, the 'windows' package provider is only available in Puppet 3.x+ If you use 2.7, you can install [this backport](http://forge.puppetlabs.com/reidmv/windows_package) or reject my PR. You won't hurt my feelings.

Cheers, 
-Ryan
